### PR TITLE
Update load_osm.py

### DIFF
--- a/GOSTnets/load_osm.py
+++ b/GOSTnets/load_osm.py
@@ -18,7 +18,7 @@ from osgeo import ogr
 from rtree import index
 from shapely import speedups
 from shapely.geometry import LineString, MultiLineString, MultiPoint, Point
-from geopy.distance import vincenty
+from geopy.distance import geodesic
 from boltons.iterutils import pairwise
 from shapely.wkt import loads,dumps
 


### PR DESCRIPTION
Vincenty has been replaced by geodesic within geopy, so without this change load_osm.py cannot be imported. https://stackoverflow.com/questions/62858552/why-cant-i-import-geopy-distance-vincenty-on-jupyter-notebook-i-installed-ge

This change solved my import issues locally, although I haven't done heavy lifting with geopy yet to test whether geodesic works similarly in all cases