### PR TITLE
CI MacOS Fix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }} with minconda
-        uses: conda-incubator/setup-miniconda@v2
+        uses: conda-incubator/setup-miniconda@v3
         with:
           python-version: ${{ matrix.python-version }}
           auto-update-conda: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,8 +10,6 @@ on:
     branches:
       - main
   push:
-    branches:
-      - main
   workflow_dispatch:
 
 # Set up jobs to spin up a virtual machine and build the package on each of


### PR DESCRIPTION
Upgrades to latest version of the GitHub Action which seems to fix the problem. Also runs the build CI workflow on all push events, not only those to the main branch.

Closes #70 